### PR TITLE
Fix build errors with clang-cl version 19 and newer

### DIFF
--- a/src/winnt_40.cpp
+++ b/src/winnt_40.cpp
@@ -62,10 +62,13 @@ LibGetFileSizeEx(HANDLE hFile, PLARGE_INTEGER lpFileSize)
 {
     if (!pfnGetFileSizeEx)
     {
-        // Check if the API is provided by kernel32, otherwise fall back to our implementation.
         HMODULE hKernel32 = GetModuleHandleW(L"kernel32");
-        pfnGetFileSizeEx = reinterpret_cast<PFN_GETFILESIZEEX>(GetProcAddress(hKernel32, "GetFileSizeEx"));
-        if (!pfnGetFileSizeEx)
+        FARPROC proc = GetProcAddress(hKernel32, "GetFileSizeEx");
+        if (proc)
+        {
+            pfnGetFileSizeEx = reinterpret_cast<PFN_GETFILESIZEEX>(reinterpret_cast<intptr_t>(proc));
+        }
+        else
         {
             pfnGetFileSizeEx = _CompatGetFileSizeEx;
         }
@@ -81,8 +84,12 @@ LibInitializeCriticalSectionAndSpinCount(LPCRITICAL_SECTION lpCriticalSection, D
     {
         // Check if the API is provided by kernel32, otherwise fall back to our implementation.
         HMODULE hKernel32 = GetModuleHandleW(L"kernel32");
-        pfnInitializeCriticalSectionAndSpinCount = reinterpret_cast<PFN_INITIALIZECRITICALSECTIONANDSPINCOUNT>(GetProcAddress(hKernel32, "InitializeCriticalSectionAndSpinCount"));
-        if (!pfnInitializeCriticalSectionAndSpinCount)
+        FARPROC proc = GetProcAddress(hKernel32, "InitializeCriticalSectionAndSpinCount");
+        if (proc)
+        {
+            pfnInitializeCriticalSectionAndSpinCount = reinterpret_cast<PFN_INITIALIZECRITICALSECTIONANDSPINCOUNT>(reinterpret_cast<intptr_t>(proc));
+        }
+        else
         {
             pfnInitializeCriticalSectionAndSpinCount = _CompatInitializeCriticalSectionAndSpinCount;
         }
@@ -96,10 +103,13 @@ LibSetFilePointerEx(HANDLE hFile, LARGE_INTEGER liDistanceToMove, PLARGE_INTEGER
 {
     if (!pfnSetFilePointerEx)
     {
-        // Check if the API is provided by kernel32, otherwise fall back to our implementation.
         HMODULE hKernel32 = GetModuleHandleW(L"kernel32");
-        pfnSetFilePointerEx = reinterpret_cast<PFN_SETFILEPOINTEREX>(GetProcAddress(hKernel32, "SetFilePointerEx"));
-        if (!pfnSetFilePointerEx)
+        FARPROC proc = GetProcAddress(hKernel32, "SetFilePointerEx");
+        if (proc)
+        {
+            pfnSetFilePointerEx = reinterpret_cast<PFN_SETFILEPOINTEREX>(reinterpret_cast<intptr_t>(proc));
+        }
+        else
         {
             pfnSetFilePointerEx = _CompatSetFilePointerEx;
         }

--- a/src/winnt_50.cpp
+++ b/src/winnt_50.cpp
@@ -173,14 +173,17 @@ _CompatInterlockedPushEntrySList(PCOMPAT_SLIST_HEADER ListHead, PCOMPAT_SLIST_EN
 }
 
 extern "C" BOOL WINAPI
-LibGetModuleHandleExW(DWORD dwFlags, LPCWSTR lpModuleName, HMODULE * phModule)
+LibGetModuleHandleExW(DWORD dwFlags, LPCWSTR lpModuleName, HMODULE* phModule)
 {
     if (!pfnGetModuleHandleExW)
     {
-        // Check if the API is provided by kernel32, otherwise fall back to our implementation.
         HMODULE hKernel32 = GetModuleHandleW(L"kernel32");
-        pfnGetModuleHandleExW = reinterpret_cast<PFN_GETMODULEHANDLEEXW>(GetProcAddress(hKernel32, "GetModuleHandleExW"));
-        if (!pfnGetModuleHandleExW)
+        FARPROC proc = GetProcAddress(hKernel32, "GetModuleHandleExW");
+        if (proc)
+        {
+            pfnGetModuleHandleExW = reinterpret_cast<PFN_GETMODULEHANDLEEXW>(reinterpret_cast<intptr_t>(proc));
+        }
+        else
         {
             pfnGetModuleHandleExW = _CompatGetModuleHandleExW;
         }
@@ -194,10 +197,13 @@ LibHeapQueryInformation(HANDLE HeapHandle, HEAP_INFORMATION_CLASS HeapInformatio
 {
     if (!pfnHeapQueryInformation)
     {
-        // Check if the API is provided by kernel32, otherwise fall back to our implementation.
         HMODULE hKernel32 = GetModuleHandleW(L"kernel32");
-        pfnHeapQueryInformation = reinterpret_cast<PFN_HEAPQUERYINFORMATION>(GetProcAddress(hKernel32, "HeapQueryInformation"));
-        if (!pfnHeapQueryInformation)
+        FARPROC proc = GetProcAddress(hKernel32, "HeapQueryInformation");
+        if (proc)
+        {
+            pfnHeapQueryInformation = reinterpret_cast<PFN_HEAPQUERYINFORMATION>(reinterpret_cast<intptr_t>(proc));
+        }
+        else
         {
             pfnHeapQueryInformation = _CompatHeapQueryInformation;
         }
@@ -211,10 +217,13 @@ LibInitializeSListHead(PCOMPAT_SLIST_HEADER ListHead)
 {
     if (!pfnInitializeSListHead)
     {
-        // Check if the API is provided by kernel32, otherwise fall back to our implementation.
         HMODULE hKernel32 = GetModuleHandleW(L"kernel32");
-        pfnInitializeSListHead = reinterpret_cast<PFN_INITIALIZESLISTHEAD>(GetProcAddress(hKernel32, "InitializeSListHead"));
-        if (!pfnInitializeSListHead)
+        FARPROC proc = GetProcAddress(hKernel32, "InitializeSListHead");
+        if (proc)
+        {
+            pfnInitializeSListHead = reinterpret_cast<PFN_INITIALIZESLISTHEAD>(reinterpret_cast<intptr_t>(proc));
+        }
+        else
         {
             pfnInitializeSListHead = _CompatInitializeSListHead;
         }
@@ -228,10 +237,13 @@ LibInterlockedFlushSList(PCOMPAT_SLIST_HEADER ListHead)
 {
     if (!pfnInterlockedFlushSList)
     {
-        // Check if the API is provided by kernel32, otherwise fall back to our implementation.
         HMODULE hKernel32 = GetModuleHandleW(L"kernel32");
-        pfnInterlockedFlushSList = reinterpret_cast<PFN_INTERLOCKEDFLUSHSLIST>(GetProcAddress(hKernel32, "InterlockedFlushSList"));
-        if (!pfnInterlockedFlushSList)
+        FARPROC proc = GetProcAddress(hKernel32, "InterlockedFlushSList");
+        if (proc)
+        {
+            pfnInterlockedFlushSList = reinterpret_cast<PFN_INTERLOCKEDFLUSHSLIST>(reinterpret_cast<intptr_t>(proc));
+        }
+        else
         {
             pfnInterlockedFlushSList = _CompatInterlockedFlushSList;
         }
@@ -245,10 +257,13 @@ LibInterlockedPushEntrySList(PCOMPAT_SLIST_HEADER ListHead, PCOMPAT_SLIST_ENTRY 
 {
     if (!pfnInterlockedPushEntrySList)
     {
-        // Check if the API is provided by kernel32, otherwise fall back to our implementation.
         HMODULE hKernel32 = GetModuleHandleW(L"kernel32");
-        pfnInterlockedPushEntrySList = reinterpret_cast<PFN_INTERLOCKEDPUSHENTRYSLIST>(GetProcAddress(hKernel32, "InterlockedPushEntrySList"));
-        if (!pfnInterlockedPushEntrySList)
+        FARPROC proc = GetProcAddress(hKernel32, "InterlockedPushEntrySList");
+        if (proc)
+        {
+            pfnInterlockedPushEntrySList = reinterpret_cast<PFN_INTERLOCKEDPUSHENTRYSLIST>(reinterpret_cast<intptr_t>(proc));
+        }
+        else
         {
             pfnInterlockedPushEntrySList = _CompatInterlockedPushEntrySList;
         }

--- a/src/winnt_51.cpp
+++ b/src/winnt_51.cpp
@@ -32,10 +32,13 @@ LibDecodePointer(PVOID Ptr)
 {
     if (!pfnDecodePointer)
     {
-        // Check if the API is provided by kernel32, otherwise fall back to our implementation.
         HMODULE hKernel32 = GetModuleHandleW(L"kernel32");
-        pfnDecodePointer = reinterpret_cast<PFN_DECODEPOINTER>(GetProcAddress(hKernel32, "DecodePointer"));
-        if (!pfnDecodePointer)
+        FARPROC proc = GetProcAddress(hKernel32, "DecodePointer");
+        if (proc)
+        {
+            pfnDecodePointer = reinterpret_cast<PFN_DECODEPOINTER>(reinterpret_cast<intptr_t>(proc));
+        }
+        else
         {
             pfnDecodePointer = _CompatDecodePointer;
         }
@@ -49,10 +52,13 @@ LibEncodePointer(PVOID Ptr)
 {
     if (!pfnEncodePointer)
     {
-        // Check if the API is provided by kernel32, otherwise fall back to our implementation.
         HMODULE hKernel32 = GetModuleHandleW(L"kernel32");
-        pfnEncodePointer = reinterpret_cast<PFN_ENCODEPOINTER>(GetProcAddress(hKernel32, "EncodePointer"));
-        if (!pfnEncodePointer)
+        FARPROC proc = GetProcAddress(hKernel32, "EncodePointer");
+        if (proc)
+        {
+            pfnEncodePointer = reinterpret_cast<PFN_ENCODEPOINTER>(reinterpret_cast<intptr_t>(proc));
+        }
+        else
         {
             pfnEncodePointer = _CompatEncodePointer;
         }


### PR DESCRIPTION
When upgrading visual studio 2022 to the latest update, clang-cl toolchain updates to versio 19 (from version 17). And a compilation error occurs refered to cast conversions on function pointers, something like this:

> error : cast from 'FARPROC' (aka 'int (*)() __attribute__((stdcall))') to 'PFN_DECODEPOINTER' (aka 'void *(*)(void *) __attribute__((stdcall))') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]

This patch addresses this issue with a two step cast conversion that convinces the compiler.