### PR TITLE
Suppress -Wcast-function-type-mismatch warnings.

### DIFF
--- a/src/winnt_40.cpp
+++ b/src/winnt_40.cpp
@@ -7,6 +7,10 @@
 // This file implements required APIs not available in Windows NT 4.0 RTM.
 #include "EnlyzeWinCompatLibInternal.h"
 
+#if defined(__clang__) && __has_warning("-Wcast-function-type-mismatch")
+#pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
+#endif
+
 typedef BOOL (WINAPI *PFN_GETFILESIZEEX)(HANDLE hFile, PLARGE_INTEGER lpFileSize);
 typedef BOOL (WINAPI *PFN_INITIALIZECRITICALSECTIONANDSPINCOUNT)(LPCRITICAL_SECTION lpCriticalSection, DWORD dwSpinCount);
 typedef BOOL (WINAPI *PFN_SETFILEPOINTEREX)(HANDLE hFile, LARGE_INTEGER liDistanceToMove, PLARGE_INTEGER lpNewFilePointer, DWORD dwMoveMethod);

--- a/src/winnt_50.cpp
+++ b/src/winnt_50.cpp
@@ -7,6 +7,10 @@
 // This file implements required APIs not available in Windows 2000 RTM (NT 5.0).
 #include "EnlyzeWinCompatLibInternal.h"
 
+#if defined(__clang__) && __has_warning("-Wcast-function-type-mismatch")
+#pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
+#endif
+
 typedef struct _COMPAT_SLIST_ENTRY
 {
     struct _COMPAT_SLIST_ENTRY* Next;

--- a/src/winnt_51.cpp
+++ b/src/winnt_51.cpp
@@ -7,6 +7,10 @@
 // This file implements required APIs not available in Windows XP RTM (NT 5.1).
 #include "EnlyzeWinCompatLibInternal.h"
 
+#if defined(__clang__) && __has_warning("-Wcast-function-type-mismatch")
+#pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
+#endif
+
 typedef PVOID (WINAPI *PFN_DECODEPOINTER)(PVOID Ptr);
 typedef PVOID (WINAPI *PFN_ENCODEPOINTER)(PVOID Ptr);
 


### PR DESCRIPTION
Clang 19 introduces this warning for casting between different function types... for some reason.