### PR TITLE
Add fallback for GetSystemTimePreciseAsFileTime() function.

### DIFF
--- a/src/EnlyzeWinCompatLib.vcxproj
+++ b/src/EnlyzeWinCompatLib.vcxproj
@@ -15,6 +15,7 @@
     <ClCompile Include="winnt_40.cpp" />
     <ClCompile Include="winnt_50.cpp" />
     <ClCompile Include="winnt_51.cpp" />
+    <ClCompile Include="winnt_61.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="EnlyzeWinCompatLibInternal.h" />
@@ -24,6 +25,7 @@
     <MASM Include="winnt_40_forwarders.asm" />
     <MASM Include="winnt_50_forwarders.asm" />
     <MASM Include="winnt_51_forwarders.asm" />
+    <MASM Include="winnt_61_forwarders.asm" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>

--- a/src/EnlyzeWinCompatLib.vcxproj.filters
+++ b/src/EnlyzeWinCompatLib.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -21,6 +21,9 @@
     <ClCompile Include="static_init.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="winnt_61.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="targetver.h">
@@ -38,6 +41,9 @@
       <Filter>Source Files</Filter>
     </MASM>
     <MASM Include="winnt_40_forwarders.asm">
+      <Filter>Source Files</Filter>
+    </MASM>
+    <MASM Include="winnt_61_forwarders.asm">
       <Filter>Source Files</Filter>
     </MASM>
   </ItemGroup>

--- a/src/winnt_61.cpp
+++ b/src/winnt_61.cpp
@@ -1,0 +1,40 @@
+//
+// EnlyzeWinCompatLib - Let Clang-compiled applications run on older Windows versions
+// Copyright (c) 2021 Colin Finck, ENLYZE GmbH <c.finck@enlyze.com>
+// SPDX-License-Identifier: MIT
+//
+
+// This file implements required APIs not available in Windows 7 RTM (NT 6.1).
+#include "EnlyzeWinCompatLibInternal.h"
+
+#if defined(__clang__) && __has_warning("-Wcast-function-type-mismatch")
+#pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
+#endif
+
+typedef VOID(WINAPI *PFN_GETSYSTEMTIMEASPRECISEFILETIME)(LPFILETIME lpSystemTimeAsFileTime);
+
+static PFN_GETSYSTEMTIMEASPRECISEFILETIME pfnGetSystemTimeAsPreciseFileTime = nullptr;
+
+static VOID WINAPI
+_CompatGetSystemTimePreciseAsFileTime(LPFILETIME lpSystemTimeAsFileTime)
+{
+	// Fall back to GetSystemTimeAsFileTime() which does the same thing but with less precision.
+	GetSystemTimeAsFileTime(lpSystemTimeAsFileTime);
+}
+
+extern "C" VOID WINAPI
+LibGetSystemTimePreciseAsFileTime(LPFILETIME lpSystemTimeAsFileTime)
+{
+	if(!pfnGetSystemTimeAsPreciseFileTime)
+	{
+		// Check if the API is provided by kernel32, otherwise fall back to our implementation.
+		HMODULE hKernel32 = GetModuleHandleW(L"kernel32");
+		pfnGetSystemTimeAsPreciseFileTime = reinterpret_cast<PFN_GETSYSTEMTIMEASPRECISEFILETIME>(GetProcAddress(hKernel32, "GetSystemTimePreciseAsFileTime"));
+		if(!pfnGetSystemTimeAsPreciseFileTime)
+		{
+			pfnGetSystemTimeAsPreciseFileTime = _CompatGetSystemTimePreciseAsFileTime;
+		}
+	}
+
+	return pfnGetSystemTimeAsPreciseFileTime(lpSystemTimeAsFileTime);
+}

--- a/src/winnt_61_forwarders.asm
+++ b/src/winnt_61_forwarders.asm
@@ -1,0 +1,16 @@
+;
+; EnlyzeWinCompatLib - Let Clang-compiled applications run on older Windows versions
+; Copyright (c) 2021 Colin Finck, ENLYZE GmbH <c.finck@enlyze.com>
+; SPDX-License-Identifier: MIT
+;
+
+.model flat
+
+EXTERN _LibGetSystemTimePreciseAsFileTime@4 : PROC
+
+.data
+
+PUBLIC __imp__GetSystemTimePreciseAsFileTime@4
+__imp__GetSystemTimePreciseAsFileTime@4 dd _LibGetSystemTimePreciseAsFileTime@4
+
+END


### PR DESCRIPTION
This isn't available in Windows XP and is needed by libc++'s chrono implementation (when compiled with _WIN32_WINNT >= _WIN32_WINNT_WIN8).

Compiling libc++ with a lower _WIN32_WINNT causes other build issues within the filesystem headers when compiling with VS2022.